### PR TITLE
[#44] Add custom `robots.txt` file

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,5 @@
+    User-agent: *
+    Disallow: /draft/
+    Disallow: /private/
+    Disallow: /admin/
+    Sitemap: https://castroforgeorgia.com/sitemap.xml


### PR DESCRIPTION
Even though the `jekyll-sitemap` plugin seems to add a `robots.txt` file on build, Lighthouse seems to consider the generated file invalid. That's either because it's missing this line:

```txt
User-agent: *
```

or because the path to the `sitemap.xml` file isn't absolute:

```txt
Sitemap: /sitemap.xml
```

This adds a custom `robots.txt` file that will override the one provided by `jekyll-sitemap` along with some future proofing of routes we'll want blocked in the case a blog or CMS is ever added. Liquid tags (eg: `{{ site.url }}`) don't seem to get parsed in `robots.txt` on build.